### PR TITLE
Rationalise Procfile triggered processes

### DIFF
--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -1,20 +1,9 @@
 #!/bin/bash -e
 
-if [ "$INSTANCE_INDEX" == 0 ]; then
-    cd ${HOME}/trade_remedies_api
-    python ./manage.py migrate 
-    python ./manage.py resetsecurity
-    python ./manage.py adminuser
-    python ./manage.py loaddata core/fixtures/*.json
-    python ./manage.py loaddata security/fixtures/*.json
-    python ./manage.py loaddata organisations/fixtures/*.json
-    python ./manage.py loaddata cases/fixtures/*.json
-    python ./manage.py load_sysparams
-    python ./manage.py s3credentials
-    python ./manage.py notify_env
-    python ./manage.py collectstatic --noinput 
-fi
-
 cd ${HOME}/trade_remedies_api
-gunicorn trade_remedies_api.wsgi --bind 0.0.0.0:$API_PORT --config trade_remedies_api/gunicorn.py
+python ./manage.py migrate 
+python ./manage.py load_sysparams
+python ./manage.py notify_env
+python ./manage.py collectstatic --noinput 
 
+gunicorn trade_remedies_api.wsgi --bind 0.0.0.0:$API_PORT --config trade_remedies_api/gunicorn.py


### PR DESCRIPTION
Remove instance check and add what seem to be the management commands which should run each time. 

The rationale being that we want migrations and collectstatic to run each time, and we also want load_sysparams and notify_env to run in case any of the sys params have been updated.

The other items have been removed because loaddata overwrites existing values with values from the fixtures, resetsecurity makes destructive changes and running s3credentials and adminuser every time is redundant.

