### PR TITLE
Org Name Update in Database Organisation Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Run `make all-requirements`
 
 This needs to be run from the host machine as it does not run in a container.
 
+## Updating the organisation name
+
+Run `python manage.py rename_trade_authority_organisation <old_name> <new_name>`
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people who contributed to this repo before it was open-sourced ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/trade_remedies_api/organisations/management/commands/rename_trade_authority_organisation.py
+++ b/trade_remedies_api/organisations/management/commands/rename_trade_authority_organisation.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand, CommandError
+from organisations.models import Organisation
+
+
+class Command(BaseCommand):
+    help = "Update the name of the Trade Authority organisation."
+
+    def add_arguments(self, parser):
+        parser.add_argument("old_name", type=str, help="old name of organisation")
+        parser.add_argument("new_name", type=str, help="new name of organisation")
+
+    def handle(self, *args, **options):
+        try:
+            trade_authority_organisation = Organisation.objects.get(name=options["old_name"])
+        except Organisation.DoesNotExist:
+            raise CommandError(f'No organisation found with name \'{options["old_name"]}\'.')
+        except Exception as e:
+            self.stdout.write(
+                self.style.ERROR( str(e) )
+            )
+            return
+        trade_authority_organisation.name = options["new_name"]
+        trade_authority_organisation.save()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Updated Trade Authority name from \'{options["old_name"]}\' to'
+                f'\'{options["new_name"]}\''
+            )
+        )
+        return

--- a/trade_remedies_api/organisations/management/commands/rename_trade_authority_organisation.py
+++ b/trade_remedies_api/organisations/management/commands/rename_trade_authority_organisation.py
@@ -1,202 +1,198 @@
 from django.core.management.base import BaseCommand, CommandError
 from organisations.models import Organisation
 from cases.models import SubmissionDocumentType
-from cases.models import CaseStage
 from core.models import JobTitle
-# from workflow.models import WorkflowTemplate
 
 
 class Command(BaseCommand):
-    help = 'Update the name and the initialism of the Trade Authority organisation in the Django Database'\
-    ' from "Trade Remedies Investigations Directorate" to "Trade Remedies Authority" and from '\
-    '"TRA" to "TRID".'
+    help = (
+        "Update the name and the initialism of the Trade Authority "
+        "organisation in the Django Database"
+        ' from "Trade Remedies Investigations Directorate" '
+        'to "Trade Remedies Authority" and from '
+        '"TRA" to "TRID".'
+    )
 
     def add_arguments(self, parser):
 
         parser.add_argument(
-            '--commit',
-            action='store_true',
-            help='Formulate updates and commit them to the database',
+            "--commit",
+            action="store_true",
+            help="Formulate updates and commit them to the database",
         )
         parser.add_argument(
-            '--nocommit',
-            action='store_true',
-            help='Formulate updates but do not commit them to the database',
+            "--nocommit",
+            action="store_true",
+            help="Formulate updates but do not commit them to the database",
         )
 
         parser.add_argument(
-            '--undo',
-            action='store_true',
+            "--undo",
+            action="store_true",
             help='Formulate updates to undo the "--commit" changes and commit them to the database',
         )
 
+    def handle_undo(self, *args, **options):
+        trade_authority_organisation = Organisation.objects.filter(
+            name="Trade Remedies Authority"
+        ).first()
+        if trade_authority_organisation:
+            trade_authority_organisation.name = "Trade Remedies Investigations Directorate"
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "undo: Can update one SubmissionDocumentType object name from "
+                    '"Trade Remedies Authority" to'
+                    '"Trade Remedies Investigations Directorate"'
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.ERROR(
+                    "TradeAuthorityOrganisation object with name "
+                    '"Trade Remedies Authority" not found'
+                )
+            )
 
+        submission_document_type = SubmissionDocumentType.objects.filter(
+            name="TRA Document",
+        ).first()
+        if submission_document_type:
+            submission_document_type.name = "TRID Document"
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "undo: Can update one SubmissionDocumentType object name from "
+                    '"TRA Document" to "TRID Document"'
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.ERROR(
+                    'SubmissionDocumentType object with name "TRID Document" not found'
+                )
+            )
+
+        job_title = JobTitle.objects.filter(name="TRA Other",).first()
+        if job_title:
+            job_title.name = "TRID Other"
+            self.stdout.write(
+                self.style.SUCCESS(
+                    'undo: Can update JobTitle object name from "TRA Other" to "TRID Other"'
+                )
+            )
+        else:
+            self.stdout.write(self.style.ERROR('JobTitle object with name "TRA Other" not found'))
+
+        if trade_authority_organisation and submission_document_type and job_title:
+            self.stdout.write(
+                self.style.SUCCESS("Committing updates for undo operation to django database")
+            )
+            try:
+                trade_authority_organisation.save()
+                submission_document_type.save()
+                job_title.save()
+            except Exception as e:
+                raise CommandError(str(e))
+        else:
+            raise CommandError(
+                "commit:  NO UPDATES COMMITTED as not all objects that require update were found."
+            )
+        return
+
+    def handle_lookups(self, *args, **options):
+        trade_authority_organisation = Organisation.objects.filter(
+            name="Trade Remedies Investigations Directorate"
+        ).first()
+        if trade_authority_organisation:
+            trade_authority_organisation.name = "Trade Remedies Authority"
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Can update one TradeAuthorityOrganisation object name from "
+                    '"Trade Remedies Investigations Directorate" to '
+                    '"Trade Remedies Authority"'
+                )
+            )
+        else:
+            raise CommandError(
+                "TradeAuthorityOrganisation object with name "
+                '"Trade Remedies Investigations Directorate" not found'
+            )
+
+        submission_document_type = SubmissionDocumentType.objects.filter(
+            name="TRID Document",
+        ).first()
+        if submission_document_type:
+            submission_document_type.name = "TRA Document"
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Can update one SubmissionDocumentType object name from "
+                    '"TRID Document" to "TRA Document"'
+                )
+            )
+        else:
+            raise CommandError('SubmissionDocumentType object with name "TRID Document" not found')
+
+        job_title = JobTitle.objects.filter(name="TRID Other",).first()
+        if job_title:
+            job_title.name = "TRA Other"
+            self.stdout.write(
+                self.style.SUCCESS(
+                    'Can update one JobTitle object name from "TRID Other" to "TRA Other"'
+                )
+            )
+        else:
+            raise CommandError('JobTitle object with name "TRID Other" not found')
+        return trade_authority_organisation, submission_document_type, job_title
 
     def handle(self, *args, **options):
 
-        if options['undo']:
-
-            trade_authority_organisation = Organisation.objects.filter(
-                    name="Trade Remedies Authority"
-            ).first()
-            if trade_authority_organisation:
-                trade_authority_organisation.name = "Trade Remedies Investigations Directorate" 
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        'undo: Can update one SubmissionDocumentType object name from '
-                        '"Trade Remedies Authority" to'
-                        '"Trade Remedies Investigations Directorate"'
-                    )
-                )
-            else:
-                self.stdout.write(
-                    self.style.ERROR(
-                        'TradeAuthorityOrganisation object with name '
-                                '"Trade Remedies Authority" not found'                    
-                    )
-                )
-    
-            submission_document_type = SubmissionDocumentType.objects.filter(
-                name="TRA Document",
-            ).first()
-            if submission_document_type:
-                submission_document_type.name = "TRID Document"
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        'undo: Can update one SubmissionDocumentType object name from '
-                        '"TRA Document" to "TRID Document"'
-                    )
-                )
-            else:
-                self.stdout.write(
-                    self.style.ERROR (
-                        'SubmissionDocumentType object with name "TRID Document" not found' 
-                    )
-                )
-                    
-            job_title = JobTitle.objects.filter(
-                name="TRA Other",
-            ).first()
-            if job_title:
-                job_title.name = "TRID Other"
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        'undo: Can update JobTitle object name from "TRA Other" to "TRID Other"'
-                    )
-                )
-            else:
-                self.stdout.write(
-                    self.style.ERROR (
-                        'JobTitle object with name "TRA Other" not found' 
-                    )
-                )
-
-            if trade_authority_organisation and submission_document_type and job_title:
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        'Committing updates for undo operation to django database' 
-                    )
-                )
-                try:
-                    trade_authority_organisation.save()
-                    submission_document_type.save()
-                    job_title.save()
-                except Exception as e:
-                    raise CommandError( str(e) )
-            else:
-                raise CommandError( 
-                    "commit:  NO UPDATES COMMITTED as not all objects that require update were found."
-                )
+        if options["undo"]:
+            self.handle_undo(self, args, options)
             return
 
-        if not options['commit'] and not options['nocommit']:
-            raise CommandError("Must run with --commit or --nocommit")
+        if not options["commit"] and not options["nocommit"]:
+            raise CommandError("Must run with --commit, --nocommit or --undo")
 
-        if options['commit'] and options['nocommit']:
+        if options["commit"] and options["nocommit"]:
             raise CommandError("Can't  run with both --commit and --nocommit")
 
-        if options['nocommit'] or options['commit']:
+        if options["nocommit"] or options["commit"]:
+            trade_authority_organisation, submission_document_type, job_title = self.handle_lookups(
+                self, args, options
+            )
 
-            trade_authority_organisation = Organisation.objects.filter(
-                    name="Trade Remedies Investigations Directorate"
-            ).first()
-            if trade_authority_organisation:
-                trade_authority_organisation.name = "Trade Remedies Authority"
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        'Can update one TradeAuthorityOrganisation object name from '
-                        '"Trade Remedies Investigations Directorate" to '
-                        '"Trade Remedies Authority"'
-                    )
-                )
-            else:
-                raise CommandError( 'TradeAuthorityOrganisation object with name '
-                                '"Trade Remedies Investigations Directorate" not found' 
-                )
-        
-            submission_document_type = SubmissionDocumentType.objects.filter(
-                name="TRID Document",
-            ).first()
-            if submission_document_type:
-                submission_document_type.name = "TRA Document"
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        'Can update one SubmissionDocumentType object name from "TRID Document" to "TRA Document"'
-                    )
-                )
-            else:
-                raise CommandError( 'SubmissionDocumentType object with name "TRID Document" not found' )
-
-            job_title = JobTitle.objects.filter(
-                name="TRID Other",
-            ).first()
-            if job_title:
-                job_title.name = "TRA Other"
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        'Can update one JobTitle object name from "TRID Other" to "TRA Other"'
-                    )
-                )
-            else:
-                raise CommandError( 'JobTitle object with name "TRID Other" not found' )
-
-        if options['nocommit']:
+        if options["nocommit"]:
             self.stdout.write(
-                self.style.ERROR(
-                    "nocommit Option selected: UPDATES NOT COMMITTED TO DATABASE"
-                )
+                self.style.ERROR("nocommit Option selected: UPDATES NOT COMMITTED TO DATABASE")
             )
             return
 
-        if options['commit']:
+        if options["commit"]:
             # do all or none
             if trade_authority_organisation and submission_document_type and job_title:
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        'Committing updates to django database' 
-                    )
-                )
+                self.stdout.write(self.style.SUCCESS("Committing updates to django database"))
                 try:
                     trade_authority_organisation.save()
                     submission_document_type.save()
                     job_title.save()
                 except Exception as e:
-                    raise CommandError( str(e) )
+                    raise CommandError(str(e))
             else:
-                raise CommandError( 
-                    "commit:  NO UPDATES COMMITTED as not all objects that require update were found."
+                raise CommandError(
+                    "commit:  NO UPDATES COMMITTED as not all objects "
+                    "that require update were found."
                 )
 
             self.stdout.write(
                 self.style.ERROR(
                     "Now please consider manual changes to the following files:\n"
-                        "- trade_remedies_api/cases/fixtures/workflow_template_anti_dumping.json;\n"
-                        "- trade_remedies_api/cases/fixtures/workflow_template_anti_subsidy.json;\n"
-                        "- trade_remedies_api/cases/fixtures/workflow_template_safeguards.json;\n"
-                        "- trade_remedies_api/cases/fixtures/workflow_template_trans_anti_dumping.json;\n"
-                        "- trade_remedies_api/cases/fixtures/workflow_template_trans_anti_subsidy.json\n"
-                        "- trade_remedies_api/cases/fixtures/workflow_template_trans_safeguards.json."  )
+                    "- trade_remedies_api/cases/fixtures/workflow_template_anti_dumping.json;\n"
+                    "- trade_remedies_api/cases/fixtures/workflow_template_anti_subsidy.json;\n"
+                    "- trade_remedies_api/cases/fixtures/workflow_template_safeguards.json;\n"
+                    "- trade_remedies_api/cases/fixtures/"
+                    "workflow_template_trans_anti_dumping.json;\n"
+                    "- trade_remedies_api/cases/fixtures/"
+                    "workflow_template_trans_anti_subsidy.json\n"
+                    "- trade_remedies_api/cases/fixtures/workflow_template_trans_safeguards.json."
+                )
             )
             return
-
-

--- a/trade_remedies_api/organisations/management/commands/rename_trade_authority_organisation.py
+++ b/trade_remedies_api/organisations/management/commands/rename_trade_authority_organisation.py
@@ -1,30 +1,101 @@
 from django.core.management.base import BaseCommand, CommandError
 from organisations.models import Organisation
+from cases.models import SubmissionDocumentType
+from cases.models import CaseStage
+from core.models import JobTitle
+# from workflow.models import WorkflowTemplate
 
 
 class Command(BaseCommand):
     help = "Update the name of the Trade Authority organisation."
 
     def add_arguments(self, parser):
-        parser.add_argument("old_name", type=str, help="old name of organisation")
-        parser.add_argument("new_name", type=str, help="new name of organisation")
+        pass
+        # parser.add_argument("old_name", type=str, help="old name of organisation")
+        # parser.add_argument("new_name", type=str, help="new name of organisation")
 
     def handle(self, *args, **options):
+
         try:
-            trade_authority_organisation = Organisation.objects.get(name=options["old_name"])
+            trade_authority_organisation = Organisation.objects.get(name="Trade Remedies Investigations Directorate")
         except Organisation.DoesNotExist:
-            raise CommandError(f'No organisation found with name \'{options["old_name"]}\'.')
+            raise CommandError(f'No organisation found with name "Trade Remedies Investigations Directorate".')
         except Exception as e:
-            self.stdout.write(
-                self.style.ERROR( str(e) )
-            )
-            return
-        trade_authority_organisation.name = options["new_name"]
-        trade_authority_organisation.save()
+            raise CommandError( e )
+        trade_authority_organisation.name = "Trade Remedies Authority"
         self.stdout.write(
             self.style.SUCCESS(
-                f'Updated Trade Authority name from \'{options["old_name"]}\' to'
-                f'\'{options["new_name"]}\''
+                'Updating Trade Authority name from "Trade Remedies Investigations Directorate" to'
+                '"Trade Remedies Authority"'
             )
         )
+ 
+        try:
+            submission_document_type = SubmissionDocumentType.objects.filter(
+                name="TRID Document",
+            ).first()
+        except SubmissionDocumentType.DoesNotExist:
+            raise CommandError('No SubmissionDocumentType found with name "TRID Document".')
+        except Exception as e:
+            raise CommandError( e )
+        submission_document_type.name = "TRA Document"
+        self.stdout.write(
+            self.style.SUCCESS(
+                'Updating SubmissionDocumentType name from "TRID Document" to "TRA Document"'
+            )
+        )
+
+        try:
+            job_title = JobTitle.objects.filter(
+                name="TRID Other",
+            ).first()
+        except JobTitle.DoesNotExist:
+            raise CommandError('No JobTitle found with name "TRID Other".')
+        except Exception as e:
+            raise CommandError( e )
+        job_title.name = "TRA Other"
+        self.stdout.write(
+            self.style.SUCCESS(
+                'Updating JobTitle name from "TRID Other" to "TRA Other"'
+            )
+        )
+
+        """
+        try:
+            case_stage = CaseStage.objects.filter(
+                label="TRID approval of the decision",
+            ).first()
+        except CaseStage.DoesNotExist:
+            raise CommandError('No CaseStage found with label "TRID approval of the decision".')
+        except Exception as e:
+            raise CommandError( e )
+        case_stage.label = "TRA approval of the decision"
+        self.stdout.write(
+            self.style.SUCCESS(
+                'Updating WorkflowTemplate from "TRID approval of the decision"'
+                ' to "TRA approval of the decision"'
+            )
+        )
+        try:
+            workflow_template = WorkflowTemplate.objects.filter(
+                label="TRID approval of the decision",
+            ).first()
+        except WorkflowTemplate.DoesNotExist:
+            raise CommandError('No WorkflowTemplate found with label "TRID approval of the decision".')
+        except Exception as e:
+            raise CommandError( e )
+        workflow_template.name = "TRA approval of the decision"
+        self.stdout.write(
+            self.style.SUCCESS(
+                'Updating WorkflowTemplate from "TRID approval of the decision"'
+                ' to "TRA approval of the decision"'
+            )
+        )
+        """
+
+
+        # trade_authority_organisation.save()
+        # submission_document_type.save()
+        # workflow_template_
+        # job_title.save()
         return

--- a/trade_remedies_api/organisations/management/commands/rename_trade_authority_organisation.py
+++ b/trade_remedies_api/organisations/management/commands/rename_trade_authority_organisation.py
@@ -7,95 +7,196 @@ from core.models import JobTitle
 
 
 class Command(BaseCommand):
-    help = "Update the name of the Trade Authority organisation."
+    help = 'Update the name and the initialism of the Trade Authority organisation in the Django Database'\
+    ' from "Trade Remedies Investigations Directorate" to "Trade Remedies Authority" and from '\
+    '"TRA" to "TRID".'
 
     def add_arguments(self, parser):
-        pass
-        # parser.add_argument("old_name", type=str, help="old name of organisation")
-        # parser.add_argument("new_name", type=str, help="new name of organisation")
+
+        parser.add_argument(
+            '--commit',
+            action='store_true',
+            help='Formulate updates and commit them to the database',
+        )
+        parser.add_argument(
+            '--nocommit',
+            action='store_true',
+            help='Formulate updates but do not commit them to the database',
+        )
+
+        parser.add_argument(
+            '--undo',
+            action='store_true',
+            help='Formulate updates to undo the "--commit" changes and commit them to the database',
+        )
+
+
 
     def handle(self, *args, **options):
 
-        try:
-            trade_authority_organisation = Organisation.objects.get(name="Trade Remedies Investigations Directorate")
-        except Organisation.DoesNotExist:
-            raise CommandError(f'No organisation found with name "Trade Remedies Investigations Directorate".')
-        except Exception as e:
-            raise CommandError( e )
-        trade_authority_organisation.name = "Trade Remedies Authority"
-        self.stdout.write(
-            self.style.SUCCESS(
-                'Updating Trade Authority name from "Trade Remedies Investigations Directorate" to'
-                '"Trade Remedies Authority"'
-            )
-        )
- 
-        try:
+        if options['undo']:
+
+            trade_authority_organisation = Organisation.objects.filter(
+                    name="Trade Remedies Authority"
+            ).first()
+            if trade_authority_organisation:
+                trade_authority_organisation.name = "Trade Remedies Investigations Directorate" 
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        'undo: Can update one SubmissionDocumentType object name from '
+                        '"Trade Remedies Authority" to'
+                        '"Trade Remedies Investigations Directorate"'
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.ERROR(
+                        'TradeAuthorityOrganisation object with name '
+                                '"Trade Remedies Authority" not found'                    
+                    )
+                )
+    
+            submission_document_type = SubmissionDocumentType.objects.filter(
+                name="TRA Document",
+            ).first()
+            if submission_document_type:
+                submission_document_type.name = "TRID Document"
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        'undo: Can update one SubmissionDocumentType object name from '
+                        '"TRA Document" to "TRID Document"'
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.ERROR (
+                        'SubmissionDocumentType object with name "TRID Document" not found' 
+                    )
+                )
+                    
+            job_title = JobTitle.objects.filter(
+                name="TRA Other",
+            ).first()
+            if job_title:
+                job_title.name = "TRID Other"
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        'undo: Can update JobTitle object name from "TRA Other" to "TRID Other"'
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.ERROR (
+                        'JobTitle object with name "TRA Other" not found' 
+                    )
+                )
+
+            if trade_authority_organisation and submission_document_type and job_title:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        'Committing updates for undo operation to django database' 
+                    )
+                )
+                try:
+                    trade_authority_organisation.save()
+                    submission_document_type.save()
+                    job_title.save()
+                except Exception as e:
+                    raise CommandError( str(e) )
+            else:
+                raise CommandError( 
+                    "commit:  NO UPDATES COMMITTED as not all objects that require update were found."
+                )
+            return
+
+        if not options['commit'] and not options['nocommit']:
+            raise CommandError("Must run with --commit or --nocommit")
+
+        if options['commit'] and options['nocommit']:
+            raise CommandError("Can't  run with both --commit and --nocommit")
+
+        if options['nocommit'] or options['commit']:
+
+            trade_authority_organisation = Organisation.objects.filter(
+                    name="Trade Remedies Investigations Directorate"
+            ).first()
+            if trade_authority_organisation:
+                trade_authority_organisation.name = "Trade Remedies Authority"
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        'Can update one TradeAuthorityOrganisation object name from '
+                        '"Trade Remedies Investigations Directorate" to '
+                        '"Trade Remedies Authority"'
+                    )
+                )
+            else:
+                raise CommandError( 'TradeAuthorityOrganisation object with name '
+                                '"Trade Remedies Investigations Directorate" not found' 
+                )
+        
             submission_document_type = SubmissionDocumentType.objects.filter(
                 name="TRID Document",
             ).first()
-        except SubmissionDocumentType.DoesNotExist:
-            raise CommandError('No SubmissionDocumentType found with name "TRID Document".')
-        except Exception as e:
-            raise CommandError( e )
-        submission_document_type.name = "TRA Document"
-        self.stdout.write(
-            self.style.SUCCESS(
-                'Updating SubmissionDocumentType name from "TRID Document" to "TRA Document"'
-            )
-        )
+            if submission_document_type:
+                submission_document_type.name = "TRA Document"
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        'Can update one SubmissionDocumentType object name from "TRID Document" to "TRA Document"'
+                    )
+                )
+            else:
+                raise CommandError( 'SubmissionDocumentType object with name "TRID Document" not found' )
 
-        try:
             job_title = JobTitle.objects.filter(
                 name="TRID Other",
             ).first()
-        except JobTitle.DoesNotExist:
-            raise CommandError('No JobTitle found with name "TRID Other".')
-        except Exception as e:
-            raise CommandError( e )
-        job_title.name = "TRA Other"
-        self.stdout.write(
-            self.style.SUCCESS(
-                'Updating JobTitle name from "TRID Other" to "TRA Other"'
-            )
-        )
+            if job_title:
+                job_title.name = "TRA Other"
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        'Can update one JobTitle object name from "TRID Other" to "TRA Other"'
+                    )
+                )
+            else:
+                raise CommandError( 'JobTitle object with name "TRID Other" not found' )
 
-        """
-        try:
-            case_stage = CaseStage.objects.filter(
-                label="TRID approval of the decision",
-            ).first()
-        except CaseStage.DoesNotExist:
-            raise CommandError('No CaseStage found with label "TRID approval of the decision".')
-        except Exception as e:
-            raise CommandError( e )
-        case_stage.label = "TRA approval of the decision"
-        self.stdout.write(
-            self.style.SUCCESS(
-                'Updating WorkflowTemplate from "TRID approval of the decision"'
-                ' to "TRA approval of the decision"'
+        if options['nocommit']:
+            self.stdout.write(
+                self.style.ERROR(
+                    "nocommit Option selected: UPDATES NOT COMMITTED TO DATABASE"
+                )
             )
-        )
-        try:
-            workflow_template = WorkflowTemplate.objects.filter(
-                label="TRID approval of the decision",
-            ).first()
-        except WorkflowTemplate.DoesNotExist:
-            raise CommandError('No WorkflowTemplate found with label "TRID approval of the decision".')
-        except Exception as e:
-            raise CommandError( e )
-        workflow_template.name = "TRA approval of the decision"
-        self.stdout.write(
-            self.style.SUCCESS(
-                'Updating WorkflowTemplate from "TRID approval of the decision"'
-                ' to "TRA approval of the decision"'
+            return
+
+        if options['commit']:
+            # do all or none
+            if trade_authority_organisation and submission_document_type and job_title:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        'Committing updates to django database' 
+                    )
+                )
+                try:
+                    trade_authority_organisation.save()
+                    submission_document_type.save()
+                    job_title.save()
+                except Exception as e:
+                    raise CommandError( str(e) )
+            else:
+                raise CommandError( 
+                    "commit:  NO UPDATES COMMITTED as not all objects that require update were found."
+                )
+
+            self.stdout.write(
+                self.style.ERROR(
+                    "Now please consider manual changes to the following files:\n"
+                        "- trade_remedies_api/cases/fixtures/workflow_template_anti_dumping.json;\n"
+                        "- trade_remedies_api/cases/fixtures/workflow_template_anti_subsidy.json;\n"
+                        "- trade_remedies_api/cases/fixtures/workflow_template_safeguards.json;\n"
+                        "- trade_remedies_api/cases/fixtures/workflow_template_trans_anti_dumping.json;\n"
+                        "- trade_remedies_api/cases/fixtures/workflow_template_trans_anti_subsidy.json\n"
+                        "- trade_remedies_api/cases/fixtures/workflow_template_trans_safeguards.json."  )
             )
-        )
-        """
+            return
 
 
-        # trade_authority_organisation.save()
-        # submission_document_type.save()
-        # workflow_template_
-        # job_title.save()
-        return


### PR DESCRIPTION
Candidate commit to address databaae update for trade authority organisation record.
Only the record in the organisation table is addressed. 
Other changes to fixtures files should also be considered, as they seem to relate to tests.  Also, some database entries - e.g. that relating to a role - could be made generic rather than TRID-specific.