### PR TITLE
hotfix: robust logging

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts =
+    --cov=trade_remedies_api/
+    --cov-report html
+    --disable-warnings
+
+DJANGO_SETTINGS_MODULE = trade_remedies_api.settings.test

--- a/requirements.in/dev.in
+++ b/requirements.in/dev.in
@@ -13,3 +13,4 @@ pytest-cov
 pytest-django
 pytest-xdist
 pytest-mock
+pytest-catchlog

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -87,19 +87,20 @@ pluggy==0.13.1            # via pytest
 prompt-toolkit==2.0.10    # via ipython
 psycopg2-binary==2.8.3    # via -r requirements.in/../requirements/base.txt, feed-gov-back
 ptyprocess==0.6.0         # via pexpect
-py==1.9.0                 # via pytest, pytest-forked
+py==1.9.0                 # via pytest, pytest-catchlog, pytest-forked
 pycodestyle==2.6.0        # via -r requirements.in/../requirements/base.txt, autopep8, flake8
 pyflakes==2.2.0           # via flake8
 pygments==2.7.1           # via -r requirements.in/../requirements/base.txt, django-silk, ipython
 pyjwt==1.7.1              # via -r requirements.in/../requirements/base.txt, notifications-python-client
 pyparsing==2.4.7          # via packaging
 pypdf2==1.26.0            # via -r requirements.in/../requirements/base.txt
+pytest-catchlog==1.2.2    # via -r requirements.in/dev.in
 pytest-cov==2.10.1        # via -r requirements.in/dev.in
 pytest-django==3.10.0     # via -r requirements.in/dev.in
 pytest-forked==1.3.0      # via pytest-xdist
 pytest-mock==3.5.1        # via -r requirements.in/dev.in
 pytest-xdist==2.1.0       # via -r requirements.in/dev.in
-pytest==6.1.1             # via -r requirements.in/dev.in, pytest-cov, pytest-django, pytest-forked, pytest-mock, pytest-xdist
+pytest==6.1.1             # via -r requirements.in/dev.in, pytest-catchlog, pytest-cov, pytest-django, pytest-forked, pytest-mock, pytest-xdist
 python-dateutil==2.8.1    # via -r requirements.in/../requirements/base.txt, botocore, django-silk, elasticsearch-dsl, freezegun, minio
 python-docx==0.8.10       # via -r requirements.in/../requirements/base.txt
 python-pptx==0.6.18       # via -r requirements.in/../requirements/base.txt

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -47,6 +47,7 @@ graphviz==0.8.3           # via -r requirements.in/../requirements/base.txt
 greenlet==0.4.17          # via -r requirements.in/../requirements/base.txt, gevent
 gunicorn==20.0.4          # via -r requirements.in/prod.in
 idna==2.8                 # via -r requirements.in/../requirements/base.txt, requests
+importlib-metadata==3.4.0  # via -r requirements.in/../requirements/base.txt, kombu
 jdcal==1.4.1              # via -r requirements.in/../requirements/base.txt, openpyxl
 jinja2==2.11.2            # via -r requirements.in/../requirements/base.txt, django-silk
 jmespath==0.10.0          # via -r requirements.in/../requirements/base.txt, boto3, botocore
@@ -83,12 +84,14 @@ sqlparse==0.3.1           # via -r requirements.in/../requirements/base.txt, dja
 striprtf==0.0.10          # via -r requirements.in/../requirements/base.txt
 titlecase==0.12.0         # via -r requirements.in/../requirements/base.txt
 toml==0.10.1              # via -r requirements.in/../requirements/base.txt, autopep8
+typing-extensions==3.7.4.3  # via -r requirements.in/../requirements/base.txt, importlib-metadata
 urllib3==1.25.10          # via -r requirements.in/../requirements/base.txt, botocore, elasticsearch, minio, requests, sentry-sdk
 vine==1.3.0               # via -r requirements.in/../requirements/base.txt, amqp, celery
 werkzeug==0.15.3          # via -r requirements.in/../requirements/base.txt
 whitenoise==3.3.1         # via -r requirements.in/../requirements/base.txt
 xlrd==1.2.0               # via -r requirements.in/../requirements/base.txt
 xlsxwriter==1.3.6         # via -r requirements.in/../requirements/base.txt, python-pptx
+zipp==3.4.0               # via -r requirements.in/../requirements/base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/trade_remedies_api/cases/receivers.py
+++ b/trade_remedies_api/cases/receivers.py
@@ -7,41 +7,60 @@ from organisations.models import Organisation
 from cases.models import Case
 from core.models import User
 
-
 logger = logging.getLogger(__name__)
 
 
 @receiver(pre_delete, sender=UserCase)
 def log_deleted_usercase(sender, instance, **kwargs):
-    logger.info(
-        f"UserCase record deleted: "
-        f"user_id = {instance.user.id}, "
-        f"email = {instance.user.email}, "
-        f"case_id = {instance.case.id}, "
-        f"case = {instance.case.name}, "
-        f"organisation_id = {instance.organisation.id}, "
-        f"organisation = {instance.organisation.name} "
-    )
+    try:
+        message = (
+            f"UserCase record deleted: "
+            f"user_id = {getattr(instance.user, 'id', 'unknown')}, "
+            f"email = {getattr(instance.user, 'email', 'unknown')}, "
+            f"case_id = {getattr(instance.case, 'id', 'unknown')}, "
+            f"case = {getattr(instance.case, 'name', 'unknown')}, "
+            f"organisation_id = {getattr(instance.organisation, 'id', 'unknown')}, "
+            f"organisation = {getattr(instance.organisation, 'name', 'unknown')} "
+        )
+    except AttributeError as e:
+        message = f"UserCase record deleted: Unable to log all details because: {e}"
+    logger.info(message)
 
 
 @receiver(pre_delete, sender=User)
 def log_deleted_user(sender, instance, **kwargs):
-    logger.info(f"User record deleted: "
-                f"user_id = {instance.id}, "
-                f"email = {instance.email}, ")
+    try:
+        message = (
+            f"User record deleted: "
+            f"user_id = {getattr(instance, 'id', 'unknown')}, "
+            f"email = {getattr(instance, 'email', 'unknown')}"
+        )
+    except AttributeError as e:
+        message = f"User record deleted: Unable to log all details because: {e}"
+    logger.info(message)
 
 
 @receiver(pre_delete, sender=Case)
 def log_deleted_case(sender, instance, **kwargs):
-    logger.info(f"Case record deleted: "
-                f"case_id = {instance.id},"
-                f" case = {instance.name}, ")
+    try:
+        message = (
+            f"Case record deleted: "
+            f"case_id = {getattr(instance, 'id', 'unknown')}, "
+            f"case = {getattr(instance, 'name', 'unknown')}"
+        )
+    except AttributeError as e:
+        message = f"Case record deleted: Unable to log all details because: {e}"
+    logger.info(message)
 
 
 @receiver(pre_delete, sender=Organisation)
 def log_deleted_organisation(sender, instance, **kwargs):
-    logger.info(
-        f"Organisation record deleted: "
-        f"organisation_id = {instance.id}, "
-        f"organisation = {instance.name}, "
-    )
+    try:
+        message = (
+            f"Organisation record deleted: "
+            f"organisation_id = {getattr(instance, 'id', 'unknown')}, "
+            f"organisation = {getattr(instance, 'name', 'unknown')}"
+        )
+    except AttributeError as e:
+        message = f"Organisation record deleted: Unable to log all details because: {e}"
+    logger.info(message)

--- a/trade_remedies_api/cases/tests/test_receivers.py
+++ b/trade_remedies_api/cases/tests/test_receivers.py
@@ -1,0 +1,172 @@
+import logging
+import pytest
+
+
+import cases.receivers as receivers
+from cases.models import Case
+from core.models import User, UserCase
+
+
+@pytest.fixture
+def user_sender(mocker):
+    """Fake receiver sender for a user."""
+    sender = mocker.Mock(spec=User)
+    return sender
+
+
+@pytest.fixture
+def case_sender(mocker):
+    """Fake receiver sender for a case."""
+    sender = mocker.Mock(spec=Case)
+    return sender
+
+
+@pytest.fixture
+def org_sender(mocker):
+    """Fake receiver sender for an organisation."""
+    sender = mocker.Mock(spec=Case)
+    return sender
+
+
+@pytest.fixture
+def user_case_sender(mocker):
+    """Fake receiver sender for a user case."""
+    sender = mocker.Mock(spec=UserCase)
+    return sender
+
+
+@pytest.fixture
+def user(mocker):
+    """Fake User instance."""
+    user = mocker.Mock()
+    user.id = "001"
+    user.email = "foo@bar.com"
+    return user
+
+
+@pytest.fixture
+def case(mocker):
+    """Fake Case instance."""
+    case = mocker.Mock()
+    case.id = "002"
+    case.name = "case-002"
+    return case
+
+
+@pytest.fixture
+def org(mocker):
+    """Fake Organisation instance."""
+    org = mocker.Mock()
+    org.id = "003"
+    org.name = "org-003"
+    return org
+
+
+@pytest.fixture
+def user_case(mocker, user, case, org):
+    """Fake UserCase instance."""
+    instance = mocker.Mock()
+    instance.user = user
+    instance.case = case
+    instance.organisation = org
+    return instance
+
+
+def test_log_deleted_usercase(caplog, user_case_sender, user_case):
+    receivers.log_deleted_usercase(user_case_sender, user_case)
+    expected = (
+        "UserCase record deleted: user_id = 001, email = foo@bar.com, "
+        "case_id = 002, case = case-002, organisation_id = 003, "
+        "organisation = org-003"
+    )
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_user(caplog, user_sender, user):
+    receivers.log_deleted_user(user_sender, user)
+    expected = "User record deleted: user_id = 001, email = foo@bar.com"
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_case(caplog, case_sender, case):
+    receivers.log_deleted_case(case_sender, case)
+    expected = "Case record deleted: case_id = 002, case = case-002"
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_organisation(caplog, org_sender, org):
+    receivers.log_deleted_organisation(org_sender, org)
+    expected = "Organisation record deleted: organisation_id = 003, " "organisation = org-003"
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_usercase_missing_user_id(mocker, caplog, user_case_sender, user_case):
+    bad_user = mocker.Mock(spec=["email"])
+    bad_user.email = "foo@bar.com"
+    user_case.user = bad_user
+    receivers.log_deleted_usercase(user_case_sender, user_case)
+    expected = (
+        "UserCase record deleted: user_id = unknown, email = foo@bar.com, "
+        "case_id = 002, case = case-002, organisation_id = 003, "
+        "organisation = org-003"
+    )
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_usercase_missing_case_id(mocker, caplog, user_case_sender, user_case):
+    bad_case = mocker.Mock(spec=["name"])
+    bad_case.name = "case-005"
+    user_case.case = bad_case
+    receivers.log_deleted_usercase(user_case_sender, user_case)
+    expected = (
+        "UserCase record deleted: user_id = 001, email = foo@bar.com, "
+        "case_id = unknown, case = case-005, organisation_id = 003, "
+        "organisation = org-003"
+    )
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_user_missing_id(mocker, caplog, user_sender):
+    bad_user = mocker.Mock(spec=["email"])
+    bad_user.email = "foo@bar.com"
+    receivers.log_deleted_user(user_sender, bad_user)
+    expected = "User record deleted: user_id = unknown, email = foo@bar.com"
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_usercase_missing_inst(mocker, caplog, user_case_sender, user_case):
+    bad_user = mocker.Mock(spec=["email"])
+    bad_user.email = "foo@bar.com"
+    user_case.user = bad_user
+    receivers.log_deleted_usercase(user_case_sender, None)
+    expected = "Unable to log all details because: 'NoneType' object has no attribute 'user'"
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_user_missing_inst(caplog, user_sender):
+    receivers.log_deleted_user(user_sender, None)
+    expected = "User record deleted: user_id = unknown, email = unknown"
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_case_missing_inst(caplog, case_sender):
+    receivers.log_deleted_case(case_sender, None)
+    expected = "Case record deleted: case_id = unknown, case = unknown"
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text
+
+
+def test_log_deleted_org_missing_inst(caplog, org_sender):
+    receivers.log_deleted_organisation(org_sender, None)
+    expected = "Organisation record deleted: organisation_id = unknown, organisation = unknown"
+    with caplog.at_level(logging.INFO):
+        assert expected in caplog.text


### PR DESCRIPTION
Recently added django signal receivers are raising an `AttributeError` (causing 500 on caseworker portal) because a user instance with no ID is being injected into the receiver. This fix makes the receivers more resilient in case of missing or invalid args.

Added failing tests for the problem, then fixed and extended. The tests were easier to implement using `pytest-catchlog` which has been added to the dev deps.

Once the hotfix is merged into `master` it should be added to develop branch.