### PR TITLE
trlst_151_hide_draft_submissions

### DIFF
--- a/trade_remedies_api/cases/admin.py
+++ b/trade_remedies_api/cases/admin.py
@@ -25,6 +25,8 @@ class SubmissionDocumentInline(admin.TabularInline):
 class SubmissionAdmin(admin.ModelAdmin):
     inlines = [SubmissionDocumentInline]
     list_display = ("case", "name", "type", "created_at", "created_by")
+    search_fields = ["case__name", "name", "type__name", "created_by__email"]
+
 
 
 class SubmissionTypeAdmin(admin.ModelAdmin):

--- a/trade_remedies_api/cases/services/api.py
+++ b/trade_remedies_api/cases/services/api.py
@@ -316,7 +316,7 @@ class CasesAPIView(TradeRemediesApiView):
                 )
                 return ResponseSuccess({"results": cases})
             elif all_cases:
-                for ocr in OrganisationCaseRole.objects.filter(organisation__id=organisation_id):
+                for ocr in OrganisationCaseRole.objects.case_prepared(organisation_id):
                     case_dict = ocr.to_embedded_dict()
                     case_dict.update(ocr.case.to_embedded_dict(organisation=self.organisation))
                     cases.append(case_dict)

--- a/trade_remedies_api/organisations/models.py
+++ b/trade_remedies_api/organisations/models.py
@@ -604,7 +604,7 @@ class Organisation(BaseModel):
 
     @property
     def case_count(self):
-        return len(OrganisationCaseRole.objects.filter(organisation=self))
+        return len(OrganisationCaseRole.objects.case_prepared(self.id))
 
     @property
     def previous_names(self):

--- a/trade_remedies_api/security/models.py
+++ b/trade_remedies_api/security/models.py
@@ -18,7 +18,7 @@ from django.conf import settings
 from django.utils import timezone
 from core.base import SimpleBaseModel
 from organisations.constants import CONTRIBUTOR_ORG_CASE_ROLE
-
+from security.constants import ROLE_PREPARING
 
 @singledispatch
 def get_role(role):
@@ -115,6 +115,9 @@ class CaseRole(models.Model):
 class OrganisationCaseRoleManager(models.Manager):
     def case_role(self, organisation, case):
         return self.filter(organisation=organisation, case=case).first()
+
+    def case_prepared(self, organisation_id):
+        return self.exclude(role=CaseRole.objects.get(id=ROLE_PREPARING)).filter(organisation__id=organisation_id)
 
     def has_organisation_case_role(self, organisation, case, role=None):
         """


### PR DESCRIPTION
Investigators using Caseworker portal get confused because "Register an Interest" submissions started by a public user (but not yet finished/submitted) appear under "Cases and Applications" on an Organisation page but don't appear on the Case Page for that organisation. 

This change applies the same filtering on the organisation page so that only _completed_ submissions are displayed.