### PR TITLE
fix: logging config.

### DIFF
--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -6,4 +6,4 @@ python ./manage.py load_sysparams
 python ./manage.py notify_env
 python ./manage.py collectstatic --noinput 
 
-gunicorn trade_remedies_api.wsgi --bind 0.0.0.0:$API_PORT --config trade_remedies_api/gunicorn.py
+gunicorn trade_remedies_api.wsgi --bind 0.0.0.0:$API_PORT --capture-output --config trade_remedies_api/gunicorn.py


### PR DESCRIPTION
Django logs were not being emitted in PaaS because gunicorn was sinking them. Added `--capture-output` config to gunicorn.