### PR TITLE
feat: assist caseworker submissions page speedup.

### DIFF
--- a/trade_remedies_api/cases/models/submissiondocument.py
+++ b/trade_remedies_api/cases/models/submissiondocument.py
@@ -86,6 +86,7 @@ class SubmissionDocument(SimpleBaseModel):
                 "downloads": self.downloads,
                 "deficient": self.deficient,
                 "sufficient": self.sufficient,
+                "needs_review": all([not self.deficient, not self.sufficient, self.document.safe]),
                 "issued": self.issued,
                 "issued_at": self.issued_at.strftime(settings.API_DATETIME_FORMAT)
                 if self.issued_at


### PR DESCRIPTION
Caseworker portal needs to decorate a submission that needs review.
The original approach made the page load excessively slow.
This change adds extra info to a submission to reduce API calls to
enable new submission display.

- Updated SubmissionDocument model 'to_dict' method to include a
  'needs_review' value inferred from a submission document that is
  safe, and not sufficient or deficient.
- Updated Submission model:
  - Moved document inclusion to 'embedded_dict' representation of
    a submission and added 'is_new_submission' dict value inferred
    from all related submission document statuses.
  - Added '_prepare_documents' helper to generate dict representation
    of a submission's documents.
  - Cleaned up some module cruft.