### PR TITLE
fix: TRLST-281 save and continue

### DIFF
--- a/trade_remedies_api/contacts/models.py
+++ b/trade_remedies_api/contacts/models.py
@@ -6,7 +6,6 @@ from django_countries.fields import CountryField
 
 
 class ContactManager(models.Manager):
-
     @staticmethod
     def create_contact(
         name,
@@ -124,10 +123,9 @@ class Contact(BaseModel):
         }
         _dict.update(
             {
-                "organisation": self.organisation.to_embedded_dict(fields=fields) if
-                self.organisation
-                else
-                {},
+                "organisation": self.organisation.to_embedded_dict(fields=fields)
+                if self.organisation
+                else {},
                 "has_user": has_user,
             }
         )
@@ -187,11 +185,16 @@ class Contact(BaseModel):
         )
         try:
             case_contact = self.casecontact_set.get(
-                contact=self, case=case, organisation=organisation,
+                contact=self,
+                case=case,
+                organisation=organisation,
             )
         except self.casecontact_set.model.DoesNotExist:
             case_contact = self.casecontact_set.create(
-                contact=self, case=case, organisation=organisation, user_context=request_by,
+                contact=self,
+                case=case,
+                organisation=organisation,
+                user_context=request_by,
             )
         case_contact.primary = True
         case_contact.save()

--- a/trade_remedies_api/contacts/models.py
+++ b/trade_remedies_api/contacts/models.py
@@ -6,8 +6,9 @@ from django_countries.fields import CountryField
 
 
 class ContactManager(models.Manager):
+
+    @staticmethod
     def create_contact(
-        self,
         name,
         email,
         created_by,
@@ -105,7 +106,7 @@ class Contact(BaseModel):
                 "post_code": self.post_code,
                 "country": {
                     "name": self.country.name if self.country else None,
-                    "code": self.country.code if self.country else None,
+                    "code": self.country.code if self.country else None,  # noqa
                 },
             }
         )
@@ -114,21 +115,32 @@ class Contact(BaseModel):
     def to_embedded_dict(self, case=None):
         has_user = self.has_user
         _dict = self.to_minimal_dict()
+        fields = {
+            "Organisation": {
+                "name": 0,
+                "address": 0,
+                "companies_house_id": 0,
+            }
+        }
         _dict.update(
             {
-                "organisation": self.organisation.to_embedded_dict() if self.organisation else {},
+                "organisation": self.organisation.to_embedded_dict(fields=fields) if
+                self.organisation
+                else
+                {},
                 "has_user": has_user,
             }
         )
         if has_user:
             user = self.userprofile.user
             user_organisation = user.organisation
-            _dict["user"] = {
-                "id": str(user.id),
+            user_dict = {
+                "id": user.id,
                 "name": user.name,
                 "email": user.email,
                 "organisation": user_organisation.to_embedded_dict() if user_organisation else {},
             }
+            _dict["user"] = user_dict  # noqa
         return _dict
 
     def to_minimal_dict(self):

--- a/trade_remedies_api/invitations/services/api.py
+++ b/trade_remedies_api/invitations/services/api.py
@@ -156,7 +156,10 @@ class InvitationsAPIView(TradeRemediesApiView):
             sent_by=request.user, context=values, direct=True, template_key=notify_template_key
         )
         return ResponseSuccess(
-            {"result": invitation.to_dict(), "created": created,},
+            {
+                "result": invitation.to_dict(),
+                "created": created,
+            },
             http_status=status.HTTP_201_CREATED,
         )
 
@@ -236,11 +239,18 @@ class AcceptInvitationAPIView(TradeRemediesApiView):
 
     def post(self, request, invitation_id, *args, **kwargs):
         try:
-            invitation = Invitation.objects.get(id=invitation_id, deleted_at__isnull=True,)
+            invitation = Invitation.objects.get(
+                id=invitation_id,
+                deleted_at__isnull=True,
+            )
             invitation.accepted_at = timezone.now()
             invitation.user = request.user
             invitation.save()
-            return ResponseSuccess({"result": invitation.to_dict(),})
+            return ResponseSuccess(
+                {
+                    "result": invitation.to_dict(),
+                }
+            )
         except Invitation.DoesNotExist:
             raise NotFoundApiExceptions("Invitation not found")
 
@@ -261,6 +271,7 @@ class InviteThirdPartyAPI(TradeRemediesApiView):
     @transaction.atomic
     def post(self, request, case_id, organisation_id, submission_id=None, *args, **kwargs):
         case = Case.objects.get(id=case_id)
+        # Get inviting organisation
         organisation = Organisation.objects.user_organisation(
             request.user, organisation_id=organisation_id
         )
@@ -301,7 +312,9 @@ class InviteThirdPartyAPI(TradeRemediesApiView):
         )
         if invite_id:
             invite = Invitation.objects.get(
-                id=invite_id, submission=submission, deleted_at__isnull=True,
+                id=invite_id,
+                submission=submission,
+                deleted_at__isnull=True,
             )
             contact = invite.contact
             contact.load_attributes(request.data, ["name", "email"])


### PR DESCRIPTION
This change fixes an issue where a third party invitee's organisation details
were not entirely returned in the json representation of a contact
Endpoint now returns organisation name, address and companies_house_id
in json representation.