### PR TITLE
feat: TRLST-306 add pip-tools to dev deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,26 @@
+SHELL := /bin/bash
+APPLICATION_NAME="Trade Remedies API"
+
+# Colour coding for output
+COLOUR_NONE=\033[0m
+COLOUR_GREEN=\033[32;01m
+COLOUR_YELLOW=\033[33;01m
+
+ifeq ($(APPLICATION_VERSION),)
+APPLICATION_VERSION := "no version"
+endif
+
+.PHONY: help test
+help:
+	@echo -e "$(COLOUR_GREEN)|--- $(APPLICATION_NAME) [$(APPLICATION_VERSION)] ---|$(COLOUR_NONE)"
+	@echo -e "$(COLOUR_YELLOW)make all-requirements$(COLOUR_NONE) : Generate all requirements (preferred usage - builds on container)"
+	@echo -e "$(COLOUR_YELLOW)make dev-requirements$(COLOUR_NONE) : Generate dev requirements (requires local pip-compile)"
+	@echo -e "$(COLOUR_YELLOW)make prod-requirements$(COLOUR_NONE) : Generate prod requirements (requires local pip-compile)"
+
 all-requirements:
-	pip-compile --output-file requirements/base.txt requirements.in/base.in
-	pip-compile --output-file requirements/dev.txt requirements.in/dev.in
-	pip-compile --output-file requirements/prod.txt requirements.in/prod.in
+	docker-compose run --rm api pip-compile --output-file requirements/base.txt requirements.in/base.in
+	docker-compose run --rm api pip-compile --output-file requirements/dev.txt requirements.in/dev.in
+	docker-compose run --rm api pip-compile --output-file requirements/prod.txt requirements.in/prod.in
 
 dev-requirements:
 	pip-compile --output-file requirements/base.txt requirements.in/base.in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "8000:8000"
     volumes:
       - ./trade_remedies_api:/app/
+      - ./requirements.in:/app/requirements.in/
+      - ./requirements:/app/requirements/
     env_file:
       - local.env
     command: python manage.py runserver 0.0.0.0:8000
@@ -41,7 +43,7 @@ services:
       - "5432:5432"
     volumes:
       - ./setup/init.sql:/docker-entrypoint-initdb.d/init.sql
-      - postgres_data:/var/lib/postgresql/data        
+      - ./postgres_data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: trade_remedies
   redis:

--- a/requirements.in/dev.in
+++ b/requirements.in/dev.in
@@ -8,6 +8,7 @@ traitlets==4.3.3
 black==19.10b0
 flake8
 coverage
+pip-tools
 pytest
 pytest-cov
 pytest-django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,8 +12,6 @@ apipkg==1.5
     # via execnet
 appdirs==1.4.4
     # via black
-appnope==0.1.2
-    # via ipython
 attrs==20.3.0
     # via
     #   black
@@ -46,7 +44,9 @@ chardet==3.0.4
     #   -r requirements.in/../requirements/base.txt
     #   requests
 click==7.1.2
-    # via black
+    # via
+    #   black
+    #   pip-tools
 colour==0.1.5
     # via -r requirements.in/../requirements/base.txt
 coverage==5.5
@@ -201,6 +201,8 @@ parso==0.8.2
     # via jedi
 pathspec==0.8.1
     # via black
+pep517==0.10.0
+    # via pip-tools
 pexpect==4.8.0
     # via ipython
 phonenumbers==8.10.20
@@ -211,6 +213,8 @@ pillow==8.1.2
     # via
     #   -r requirements.in/../requirements/base.txt
     #   python-pptx
+pip-tools==6.1.0
+    # via -r requirements.in/dev.in
 pluggy==0.13.1
     # via pytest
 prompt-toolkit==3.0.18
@@ -316,6 +320,7 @@ titlecase==0.12.0
 toml==0.10.2
     # via
     #   black
+    #   pep517
     #   pytest
 traitlets==4.3.3
     # via
@@ -358,4 +363,5 @@ zope.interface==5.4.0
     #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
TRLST 304 introduced an improved mechanism in TR public service
to use pip-compile on the container rather than in the developer's
local env.

However, pip-tools (required for pip-compile) is not in the
API/Public/Caseworker deps and therefore does not get included
in the container build.

This change adds pip-tools as a dev dep, and also performs
on-container build of requirements.