### PR TITLE
Fix - TRSV2-581 - Caseworker-invite-wrong-case-role

### DIFF
--- a/trade_remedies_api/invitations/models.py
+++ b/trade_remedies_api/invitations/models.py
@@ -742,7 +742,7 @@ class Invitation(BaseModel):
                 organisation=self.organisation,
                 case=self.case,
                 defaults={
-                    "role": self.case_role,
+                    "role": CaseRole.objects.get(id=ROLE_AWAITING_APPROVAL),
                     "sampled": True,
                     "created_by": self.user,
                 },


### PR DESCRIPTION
Caseworker invite now creates an AWATING_APPROVAL organisation_case_role object instead of the org case role that the caseworker invited from.